### PR TITLE
Fixed UTF8 support for calendar entries

### DIFF
--- a/lib/CalDAV/Sender.pm
+++ b/lib/CalDAV/Sender.pm
@@ -212,7 +212,7 @@ sub send {
 		my $request = $self->_request(PUT => $url_full .qq(/$uid.ics));
 		$request->header(q(Content-Type) => q(text/calendar; charset=UTF-8));
 		$request->header(q(Content-Encoding) => q(UTF-8));
-		$request->add_content(qq(BEGIN:VCALENDAR\r\n) . $event->as_string . q(END:VCALENDAR));
+		$request->add_content(qq(BEGIN:VCALENDAR\r\n) . Encode::encode_utf8($event->as_string) . q(END:VCALENDAR));
 		printf STDERR qq/\t%s (%s) - /, $uid, $sum;
 
 		my $response = $ua->request($request);


### PR DESCRIPTION
I had a problem with a calendar that contained "special" chars. Try http://www.1823.gov.hk/common/ical/en.ics (note that all the ' chars seem to be some special chars...)
I'm not a perl pro, but the attached patch fixes it for me (it shows up nicely on the server as well)
